### PR TITLE
feat: detect an error when trusted publisher status is lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `danielroe/provenance-action`
 
-Detect dependencies that lost npm provenance (trusted publishing) from your lockfile.
+Detect and fail CI when dependencies in your lockfile lose npm provenance or trusted publisher status.
 
 > [!WARNING]  
 > This action is under active development and is only one tool to assist in securing your dependencies.
@@ -53,6 +53,17 @@ jobs:
 2. Checks npm provenance via the attestations API for each `name@version`.
 3. Falls back to version metadata for `dist.attestations`.
 4. Emits file+line annotations in the lockfile.
+
+## 🔒 Why this matters
+Trusted publishing links a package back to its source repo and build workflow, providing strong provenance guarantees. It helps ensure the package you install corresponds to audited source and CI.
+
+However, maintainers can still be phished or coerced into publishing without trusted publishing enabled, or switching to a non‑trusted path. In those cases, packages may still carry attestations, but the chain back to the trusted publisher can be weakened.
+
+This action:
+- Detects when a dependency update loses npm provenance (no attestations) or loses trusted publisher (attestations but no trusted publisher marker), and
+- Fails CI by default (configurable), before that change lands in your main branch.
+
+This is a stopgap until package managers enforce stronger policies natively. Until then, it offers a lightweight guardrail in CI.
 
 ## ⚠️ Notes
 - Runs on Node 24+ and executes the TypeScript entrypoint directly.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ jobs:
 - `lockfile` (optional): Path to the lockfile. Auto-detected if omitted.
 - `workspace-path` (optional): Path to workspace root. Default: `.`
 - `base-ref` (optional): Git ref to compare against. Default: `origin/main`.
-- `fail-on-downgrade` (optional): If `true`, the step exits non‑zero on downgrade. Default: `true`.
+- `fail-on-downgrade` (optional): Controls failure behavior. Accepts `true`, `false`, `any`, or `only-provenance-loss`. Default: `true` (which is the same as `any`).
 
 ## 📤 Outputs
-- `downgraded`: JSON array of `{ name, from, to }` for packages that lost provenance.
+- `downgraded`: JSON array of `{ name, from, to, downgradeType }` for detected downgrades. `downgradeType` is `provenance` or `trusted_publisher`.
 
 ## 🧠 How it works
 1. Diffs your lockfile against the base ref and collects changed resolved versions (including transitives).

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Provenance downgrade check'
-description: 'GitHub Action that detects dependency provenance downgrades from lockfile changes (npm/pnpm/yarn).'
+description: 'Detect and fail CI when dependencies in your lockfile lose npm provenance or trusted publisher status.'
 author: 'Daniel Roe (@danielroe)'
 
 # Add your action's branding here. This will appear on the GitHub Marketplace.

--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,13 @@ inputs:
     description: 'Git ref to compare against (e.g., origin/main)'
     required: false
   fail-on-downgrade:
-    description: 'Fail the job if a downgrade is detected'
+    description: 'Fail behavior: true|false|any|only-provenance-loss (default: true)'
     required: false
     default: 'true'
 
 outputs:
   downgraded:
-    description: 'JSON array of { name, from, to } for versions that lost provenance'
+    description: 'JSON array of { name, from, to, downgradeType } for detected downgrades'
 
 runs:
   using: node24

--- a/test/provenance.test.ts
+++ b/test/provenance.test.ts
@@ -1,9 +1,13 @@
 import { test } from 'node:test'
 import { strict as assert } from 'node:assert'
-import { hasProvenance } from '../lib/index.ts'
+import { hasProvenance, hasTrustedPublisher } from '../lib/index.ts'
 
 test('hasProvenance detects known provenance package versions', async () => {
   const cache = new Map<string, boolean>()
   assert.equal(await hasProvenance('nuxt', '4.1.2', cache), true)
   assert.equal(await hasProvenance('nuxt', '3.0.0', cache), false)
+  
+  assert.equal(await hasTrustedPublisher('nuxt', '4.1.2', cache), true)
+  assert.equal(await hasTrustedPublisher('nuxt', '3.13.0', cache), false)
+  assert.equal(await hasProvenance('nuxt', '3.13.0', cache), false)
 })


### PR DESCRIPTION
this adds an additional check - if you previously had [trusted publisher status](https://docs.npmjs.com/trusted-publishers) but you lost it but still have _some_ provenance, this will now fail CI by default