### PR TITLE
doc: only run workflows on PRs changing the lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      # Trigger a run only on PRs that change the lockfile
+      # (keep whichever is relevant and/or configure its path):
+      - pnpm-lock.yaml
+      - package-lock.json
+      - yarn.lock
+      - bun.lock
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
The example workflow in the README could use the [`on.pull_request.paths`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore) filter to only trigger on PRs that target the lockfile.

The drawback is to have to explicitly specify your lockfile (which goes against the automatic detection), but helps save CI costs & energy.