### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "provenance-action",
   "type": "module",
   "version": "0.0.2",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@11.1.2",
   "description": "GitHub Action that fails CI when dependencies in your lockfile lose npm provenance or trusted publisher status",
   "author": "Daniel Roe <daniel@roe.dev>",
   "license": "MIT",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
   esbuild: false
-  simple-git-hooks: false
+  simple-git-hooks: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 allowBuilds:
   esbuild: false
   simple-git-hooks: true
+
+shellEmulator: true
+
+trustPolicy: no-downgrade


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`